### PR TITLE
style(login-success): Update font sizes for better readability

### DIFF
--- a/src/components/LoginSuccess/LoginSuccess.css
+++ b/src/components/LoginSuccess/LoginSuccess.css
@@ -98,7 +98,7 @@
 
 .skills-label {
   margin: 2px 0; /* 새로 추가 */
-  font-size: 14px;
+  font-size: 16px;
   font-weight: bold;
 }
 
@@ -113,8 +113,7 @@
   white-space: nowrap; /* Ensure items stay in a single line */
   overflow-x: auto; /* Enable horizontal scrolling */
   gap: 8px;
-  margin: 10px 0;
-  padding-bottom: 10px; /* Space for scrollbar */
+  margin: 12px 0;
   padding-right: 20px; /* Space for fade */
   scrollbar-width: none;
   -ms-overflow-style: none;
@@ -180,7 +179,7 @@
   -ms-overflow-style: none; /* IE & Edge */
 }
 .certificate-container {
-  font-size: 11px;
+  font-size: 13px;
   color: #000000;
   display: block;
   text-align: center;


### PR DESCRIPTION
- 스킬 레이블의 글꼴 크기를 14px에서 16px로 변경했습니다.
- 자격증 컨테이너의 글꼴 크기를 11px에서 13px로 변경했습니다.
- 마진을 조정하여 요소 간의 간격을 개선했습니다.