### PR TITLE
feat(auth): Initialize session rejection handling

### DIFF
--- a/src/hooks/useInitializeSession.ts
+++ b/src/hooks/useInitializeSession.ts
@@ -3,14 +3,16 @@ import { useAppDispatch } from '../store/hooks';
 import { initializeAuth } from './useAuth';
 import { getMember } from './userUser';
 import { getAccessToken } from '../utils/tokenManager';
+import { setInitializeRejected } from '../store/slices/authSlice';
 
 const useInitializeSession = () => {
   const dispatch = useAppDispatch();
   const initialized = useRef(false);
 
   useEffect(() => {
-    // 세션 스토리지에 토큰이 없으면 아예 시도하지 않음
+    // 세션 스토리지에 토큰이 없으면 초기화를 rejected 상태로 설정
     if (!getAccessToken()) {
+      dispatch(setInitializeRejected());
       return;
     }
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -8,7 +8,7 @@ import ResumePage from '../pages/ResumePage';
 import PolicyPage from '../pages/PolicyPage';
 import DiagnosisPage from '../pages/DiagnosisPage';
 import MatchingPage from '../pages/MatchingPage';
-//import ProtectedRoute from './ProtectedRoute';
+import ProtectedRoute from './ProtectedRoute';
 
 const AppRoutes = () => {
   return (
@@ -18,23 +18,28 @@ const AppRoutes = () => {
       <Route
         path="/settings"
         element={
-          // <ProtectedRoute>
-          <SettingsPage />
-          // </ProtectedRoute>
+          <ProtectedRoute>
+            <SettingsPage />
+          </ProtectedRoute>
         }
       />
-      {/* 설정 페이지 경로 추가 */}
-      <Route path="/signup" element={<SignUpForm />} /> {/* 회원가입페이지 */}
+      <Route path="/signup" element={<SignUpForm />} />
       <Route
         path="/resume"
         element={
-          // <ProtectedRoute>
-          <ResumePage />
-          // </ProtectedRoute>
+          <ProtectedRoute>
+            <ResumePage />
+          </ProtectedRoute>
         }
       />
-      {/* 이력서 페이지 경로 */}
-      <Route path="/diagnosis" element={<DiagnosisPage />} /> {/* 역량 진단 페이지 */}
+      <Route
+        path="/diagnosis"
+        element={
+          <ProtectedRoute>
+            <DiagnosisPage />
+          </ProtectedRoute>
+        }
+      />
       <Route path="/matching" element={<MatchingPage />} />
       <Route path="/training" element={<TariningCoursePage />} /> {/* 직업 훈련 페이지 */}
       <Route path="/policy" element={<PolicyPage />} /> {/* 정책 페이지 */}

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -21,6 +21,10 @@ const authSlice = createSlice({
       state.error = null;
       clearAccessToken(); // 메모리에서 Access Token 제거
     },
+    setInitializeRejected: (state: AuthState) => {
+      state.status.initialize = 'rejected';
+      state.isAuthenticated = false;
+    },
   },
   extraReducers: (builder) => {
     // 로그인 처리
@@ -76,5 +80,5 @@ const authSlice = createSlice({
   },
 });
 
-export const { logout } = authSlice.actions;
+export const { logout, setInitializeRejected } = authSlice.actions;
 export default authSlice.reducer;


### PR DESCRIPTION
- 세션 스토리지에 토큰이 없을 경우 초기화를 rejected 상태로 설정하도록 변경했습니다.
- authSlice에 setInitializeRejected 액션을 추가하여 상태 관리를 개선했습니다.
- ProtectedRoute를 사용하여 설정 및 진단 페이지 접근을 보호했습니다.