### PR TITLE
feat(routes): Improve authentication check logic

### DIFF
--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -9,8 +9,12 @@ const ProtectedRoute = ({ children }: { children: JSX.Element }) => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // 초기화가 진행 중이 아니고, 인증되지 않은 경우 로그인 페이지로 이동
-    if (status.initialize !== 'pending' && !isAuthenticated) {
+    // 초기화가 완전히 완료된 후(fulfilled 또는 rejected)에만 인증 체크
+    // idle 상태는 아직 초기화가 시작되지 않았거나 로그아웃 직후 상태이므로 제외
+    const isInitializationComplete = status.initialize === 'fulfilled' || status.initialize === 'rejected';
+
+    // 초기화가 완료되고, 인증되지 않은 경우에만 로그인 페이지로 이동
+    if (isInitializationComplete && !isAuthenticated) {
       Swal.fire({
         title: '로그인이 필요합니다',
         text: '로그인 하시겠습니까?',

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -17,7 +17,7 @@ const authSlice = createSlice({
     logout: (state: AuthState) => {
       state.isAuthenticated = false;
       state.accessToken = null;
-      state.status = { login: 'idle', initialize: 'idle' };
+      state.status = { login: 'idle', initialize: 'rejected' };
       state.error = null;
       clearAccessToken(); // 메모리에서 Access Token 제거
     },


### PR DESCRIPTION
- 초기화가 완료된 후에만 인증 체크를 수행하도록 변경했습니다.
- 인증되지 않은 경우 로그인 페이지로 리다이렉트합니다.
- 상태 관리의 일관성을 높이기 위해 초기화 상태를 'rejected'로 설정했습니다.