### PR TITLE
feat(service-card): Update styles and descriptions for service cards

### DIFF
--- a/src/components/ServiceCard/ServiceCard.css
+++ b/src/components/ServiceCard/ServiceCard.css
@@ -1,6 +1,6 @@
 .service-card {
-  width: 200px; /* 카드 너비 */
-  height: 280px; /* 카드 높이 */
+  width: 215px; /* 카드 너비 */
+  height: 260px; /* 카드 높이 */
   display: flex;
   flex-direction: column;
   border: 1px solid #ddd;
@@ -30,13 +30,12 @@
 }
 
 .service-card-title {
-  font-size: 16px;
+  font-size: 17px;
   margin: 0 0 8px 0;
 }
 
 .service-card-description {
   color: #666;
-  margin-bottom: 20px;
   display: -webkit-box;
   -webkit-line-clamp: 3; /* 최대 3줄까지 표시 */
   line-clamp: 3; /* 표준 속성 추가 */
@@ -45,6 +44,19 @@
   text-overflow: ellipsis;
   white-space: normal;
   word-break: break-word;
+}
+
+.service-card-go {
+  font-size: 15px;
+  color: #666;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.service-card-go svg {
+  font-size: 19px;
 }
 
 /* --- 반응형 추가 (모바일 대응) --- */

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -55,7 +55,7 @@ const MainPage: React.FC = () => {
           <ServiceCard
             imageUrl="/icons/service3.svg"
             serviceName="나의 역량 진단"
-            serviceDescription="사용자의 희망 직무와 비교해 부족한 역량을 보완할 수 있는 방법을 제공합니다."
+            serviceDescription="부족한 역량을 보완할 수 있는 방법을 제공합니다."
             link="/diagnosis"
           />
           <ServiceCard

--- a/src/styles/MainPage.module.css
+++ b/src/styles/MainPage.module.css
@@ -20,17 +20,17 @@
 
 .service-card-section {
   display: flex;
-  justify-content: center;
+  justify-content: space-evenly;
   align-items: center;
   flex-wrap: wrap;
-  gap: var(--spacing-xl);
   border: 1px solid var(--border-color);
   border-radius: var(--border-radius-large);
   box-shadow: var(--shadow-deep);
   height: auto;
   min-height: 300px;
   box-sizing: border-box;
-  padding: var(--spacing-large);
+  padding-bottom: 40px;
+  padding-top: 40px;
 }
 
 .job-posting-section {


### PR DESCRIPTION
- 서비스 카드의 크기와 폰트 크기를 조정했습니다.
- 서비스 설명을 간결하게 수정하여 가독성을 높였습니다.
- 서비스 카드 섹션의 정렬 방식을 변경하여 레이아웃을 개선했습니다.

### 수정 전
<img width="1157" height="301" alt="스크린샷 2025-12-02 오전 11 47 39" src="https://github.com/user-attachments/assets/f850a890-7bf0-43d7-956b-573b3242eb6c" />

### 수정 후
<img width="1162" height="320" alt="스크린샷 2025-12-02 오전 11 47 22" src="https://github.com/user-attachments/assets/86474b57-2f62-44c7-b7a2-55fb93352d18" />
